### PR TITLE
Implement AI summary via MeaningCloud API

### DIFF
--- a/index.html
+++ b/index.html
@@ -664,6 +664,31 @@
             return summary.length > 1 ? summary : "Konnte keine Zusammenfassung erstellen.";
         }
 
+        async function fetchMeaningCloudSummary(text, sentences = 3) {
+            const apiKey = 'YOUR_MEANINGCLOUD_API_KEY'; // Replace with your free MeaningCloud key
+            const params = new URLSearchParams();
+            params.append('key', apiKey);
+            params.append('txt', text);
+            params.append('sentences', sentences);
+
+            const response = await fetch('https://api.meaningcloud.com/summarization-1.0', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: params.toString()
+            });
+
+            if (!response.ok) {
+                throw new Error(`Summarization API Fehler: ${response.status} ${response.statusText}`);
+            }
+
+            const result = await response.json();
+            if (result && result.summary) {
+                return result.summary;
+            }
+
+            throw new Error('Keine Zusammenfassung vom API erhalten.');
+        }
+
         // --- Event-Listener für Suchfeld ---
         searchInput.addEventListener('input', () => {
             clearTimeout(debounceTimeout);
@@ -757,12 +782,15 @@
                                                .filter(text => text && text.trim() !== "");
 
                     if (textsToSummarize.length > 0) {
-                        const summary = generateSimpleSummary(textsToSummarize, 3);
-                        // Consider using .textContent if summary is plain text
-                                                            // If summary can contain HTML, .innerHTML is fine.
-                                                            // For simple text, textContent is safer.
-                                                            // Given generateSimpleSummary, textContent is better.
-                        aiSummaryContent.textContent = summary;
+                        const combined = textsToSummarize.join(' ');
+                        try {
+                            const summary = await fetchMeaningCloudSummary(combined, 3);
+                            aiSummaryContent.textContent = summary;
+                        } catch (apiError) {
+                            console.warn('Summarization API fehlgeschlagen, nutze einfache Zusammenfassung:', apiError);
+                            const fallback = generateSimpleSummary(textsToSummarize, 3);
+                            aiSummaryContent.textContent = fallback;
+                        }
                     } else {
                         aiSummaryContent.textContent = "Nicht genügend Inhalte in den Suchergebnissen für eine Zusammenfassung.";
                     }


### PR DESCRIPTION
## Summary
- integrate MeaningCloud summarization API
- fall back to simple summarization when API fails

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841ade7fe88832b96f3e667a0bd780d